### PR TITLE
Issue/51

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,9 +9,10 @@ on:
 
   workflow_dispatch:
 
-permission:
+permissions:
   id-token: write
   contents: read
+  actions: read
 
 jobs:
   deploy:
@@ -22,9 +23,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: app-release
+        run-id: ${{ github.event.workflow_run.id }}
         path: ./build-artifacts
 
     - name: 'Authenticate to Google Cloud'
+      id: auth
       uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,8 @@ on:
     types:
       - completed
     branches: [deploy, hotfix, issue/cd]
+  push:
+    branches: [issue/cd]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
     - name: 'Authenticate to Google Cloud'
       uses: google-github-actions/auth@v2
       with:
-        workload_identity_provider: ${{secret.WORKLOAD_IDENTITY_PROVIDER}}
+        workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: barlow-app-publish@barlow-app.iam.gserviceaccount.com
         token_format: json
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: barlow-app-publish@barlow-app.iam.gserviceaccount.com
-        token_format: access-token
+        token_format: access_token
 
 #    - name: Download app-release.aab from artifacts
 #      uses: actions/download-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,41 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["어플리케이션 빌드"]
+    types:
+      - completed
+    branches: [deploy, hotfix, issue/cd]
+
+  workflow_dispatch:
+
+permission:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Download app-release.aab from artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: app-release
+        path: ./build-artifacts
+
+    - name: 'Authenticate to Google Cloud'
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{secret.WORKLOAD_IDENTITY_PROVIDER}}
+        service_account: barlow-app-publish@barlow-app.iam.gserviceaccount.com
+        token_format: json
+
+    - name: Play Console 내부테스트 배포
+      uses: r0adkll/upload-google-play@v1
+      with:
+        serviceAccountJsonPlainText: ${{ steps.auth.outputs.credentials_json }}
+        packageName: com.barlow.front
+        releaseFile: build-artifacts/app-release.aab
+        track: internal
+        status: completed

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -105,7 +105,7 @@ jobs:
         VERSION_CODE=$(curl -s -X GET \
           -H "Authorization: Bearer $ACCESS_TOKEN" \
           "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID/bundles" \
-          | jq -r '.bundles[0].versionCode')
+          | jq -r '.bundles | max_by(.versionCode) | .versionCode')
         echo "Uploaded bundle versionCode: $VERSION_CODE"
         
         echo "📌 3. Assign to Track"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,8 +27,9 @@ jobs:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: barlow-app-publish@barlow-app.iam.gserviceaccount.com
         token_format: access_token
+        access_token_scopes: https://www.googleapis.com/auth/androidpublisher
 
-#    - name: Download app-release.aab from artifacts
+      #    - name: Download app-release.aab from artifacts
 #      uses: actions/download-artifact@v4
 #      with:
 #        name: app-release

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: barlow-app-publish@barlow-app.iam.gserviceaccount.com
-        token_format: json
+        token_format: access-token
 
 #    - name: Download app-release.aab from artifacts
 #      uses: actions/download-artifact@v4
@@ -60,12 +60,64 @@ jobs:
           --dir build-artifacts
 
         ls -lh build-artifacts
-
-    - name: Play Console 내부테스트 배포
-      uses: r0adkll/upload-google-play@v1
-      with:
-        serviceAccountJsonPlainText: ${{ steps.auth.outputs.credentials_json }}
-        packageName: com.barlow.front
-        releaseFile: build-artifacts/app-release.aab
-        track: internal
-        status: completed
+#
+#    - name: Play Console 내부테스트 배포
+#      uses: r0adkll/upload-google-play@v1
+#      with:
+#        serviceAccountJsonPlainText: ${{ steps.auth.outputs.credentials_json }}
+#        packageName: com.barlow.front
+#        releaseFile: build-artifacts/app-release.aab
+#        track: internal
+#        status: completed
+    - name: Deploy to Play Store
+      env:
+        ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+        PACKAGE_NAME: com.barlow.front
+        TRACK: internal
+      run: |
+        set -e
+        
+        echo "📌 1. Create Edit"
+        EDIT_ID=$(curl -s -X POST \
+          -H "Authorization: Bearer $ACCESS_TOKEN" \
+          -H "Content-Type: application/json" \
+          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits" \
+          | jq -r '.id')
+        echo "Got editId: $EDIT_ID"
+        
+        echo "📌 2. Upload AAB"
+        UPLOAD_URL="https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID/bundles?uploadType=resumable"
+        SESSION_URL=$(curl -s -X POST \
+          -H "Authorization: Bearer $ACCESS_TOKEN" \
+          -H "X-Upload-Content-Type: application/octet-stream" \
+          -H "Content-Type: application/octet-stream" \
+          --data-binary @build-artifacts/app-release.aab \
+          "$UPLOAD_URL" \
+          -D - | grep -i location | awk '{print $2}' | tr -d '\r')
+        
+        # 실제 업로드 (resumable session)
+        curl -X PUT \
+          -H "Authorization: Bearer $ACCESS_TOKEN" \
+          -H "Content-Type: application/octet-stream" \
+          --data-binary @build-artifacts/app-release.aab \
+          "$SESSION_URL"
+        
+        VERSION_CODE=$(curl -s -X GET \
+          -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID/bundles" \
+          | jq -r '.bundles[0].versionCode')
+        echo "Uploaded bundle versionCode: $VERSION_CODE"
+        
+        echo "📌 3. Assign to Track"
+        curl -s -X PUT \
+          -H "Authorization: Bearer $ACCESS_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d "{\"releases\": [{\"versionCodes\": [\"$VERSION_CODE\"], \"status\": \"completed\"}]}" \
+          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID/tracks/$TRACK"
+        
+        echo "📌 4. Commit Edit"
+        curl -s -X POST \
+          -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID:commit"
+        
+        echo "✅ Deployment to $TRACK completed"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,13 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Download app-release.aab from artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: app-release
-        run-id: ${{ github.event.workflow_run.id }}
-        path: ./build-artifacts
-
     - name: 'Authenticate to Google Cloud'
       id: auth
       uses: google-github-actions/auth@v2
@@ -34,6 +27,39 @@ jobs:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: barlow-app-publish@barlow-app.iam.gserviceaccount.com
         token_format: json
+
+#    - name: Download app-release.aab from artifacts
+#      uses: actions/download-artifact@v4
+#      with:
+#        name: app-release
+#        run-id: ${{ github.event.workflow_run.id }}
+#        path: ./build-artifacts
+#
+    - name: Download latest CI artifact (app-release)
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # CI 워크플로우 이름 (ci.yml에서 설정한 name과 일치해야 함)
+        CI_WORKFLOW="어플리케이션 빌드"
+
+        # 가장 최근 성공한 CI 실행의 run id 찾기
+        CI_RUN_ID=$(gh run list \
+          --workflow "$CI_WORKFLOW" \
+          --branch deploy \
+          --status success \
+          --limit 1 \
+          --json databaseId \
+          --jq '.[0].databaseId')
+
+        echo "ℹ️ Latest CI run id: $CI_RUN_ID"
+
+        # 해당 run의 artifact 다운로드
+        mkdir -p build-artifacts
+        gh run download "$CI_RUN_ID" \
+          --name app-release \
+          --dir build-artifacts
+
+        ls -lh build-artifacts
 
     - name: Play Console 내부테스트 배포
       uses: r0adkll/upload-google-play@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,15 +64,7 @@ jobs:
           --dir build-artifacts
 
         ls -lh build-artifacts
-#
-#    - name: Play Console 내부테스트 배포
-#      uses: r0adkll/upload-google-play@v1
-#      with:
-#        serviceAccountJsonPlainText: ${{ steps.auth.outputs.credentials_json }}
-#        packageName: com.barlow.front
-#        releaseFile: build-artifacts/app-release.aab
-#        track: internal
-#        status: completed
+
     - name: Deploy to Play Store
       env:
         ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
@@ -94,15 +86,16 @@ jobs:
         
         echo "📌 2. Upload AAB"
         UPLOAD_URL="https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID/bundles?uploadType=resumable"
-        SESSION_URL=$(curl -s -X POST \
+        
+        SESSION_URL=$(curl -s -D - -o /dev/null \
           -H "Authorization: Bearer $ACCESS_TOKEN" \
           -H "X-Upload-Content-Type: application/octet-stream" \
           -H "Content-Type: application/octet-stream" \
-          --data-binary @build-artifacts/app-release.aab \
-          "$UPLOAD_URL" \
-          -D - | grep -i location | awk '{print $2}' | tr -d '\r')
+          -X POST "$UPLOAD_URL" \
+          | grep -Fi Location | awk '{print $2}' | tr -d '\r')
+
+        echo "Got session URL: $SESSION_URL"
         
-        # 실제 업로드 (resumable session)
         curl -X PUT \
           -H "Authorization: Bearer $ACCESS_TOKEN" \
           -H "Content-Type: application/octet-stream" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,13 +79,16 @@ jobs:
         TRACK: internal
       run: |
         set -e
-        
+
         echo "📌 1. Create Edit"
-        EDIT_ID=$(curl -s -X POST \
-          -H "Authorization: Bearer $ACCESS_TOKEN" \
-          -H "Content-Type: application/json" \
-          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits" \
-          | jq -r '.id')
+        EDIT_RESPONSE=$(curl -s -X POST \
+        -H "Authorization: Bearer $ACCESS_TOKEN" \
+        -H "Content-Type: application/json" \
+        "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits")
+        
+        echo "Full response: $EDIT_RESPONSE"
+         
+        EDIT_ID=$(echo "$EDIT_RESPONSE" | jq -r '.id')
         echo "Got editId: $EDIT_ID"
         
         echo "📌 2. Upload AAB"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,6 @@ on:
     types:
       - completed
     branches: [deploy, hotfix, issue/cd]
-
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -118,6 +118,6 @@ jobs:
         echo "📌 4. Commit Edit"
         curl -s -X POST \
           -H "Authorization: Bearer $ACCESS_TOKEN" \
-          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID:commit"
+          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID:commit?changesNotSentForReview=true"
         
         echo "✅ Deployment to $TRACK completed"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,12 +81,12 @@ jobs:
         set -e
         
         echo "📌 1. Create Edit"
-        EDIT_RESPONSE=$(curl -s -X POST \
+        EDIT_ID=$(curl -s -X POST \
           -H "Authorization: Bearer $ACCESS_TOKEN" \
           -H "Content-Type: application/json" \
-          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits")
-        echo "Got editId: $EDIT_RESPONSE"
-        echo << (echo "$EDIT_RESPONSE" | jq -r '.id')
+          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits" \
+          | jq -r '.id')
+        echo "Got editId: $EDIT_ID"
         
         echo "📌 2. Upload AAB"
         UPLOAD_URL="https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID/bundles?uploadType=resumable"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,7 @@ on:
     workflows: ["어플리케이션 빌드"]
     types:
       - completed
-    branches: [deploy, hotfix, issue/cd]
-  push:
-    branches: [issue/cd]
+    branches: [main, hotfix, dev, release]
   workflow_dispatch:
 
 permissions:
@@ -29,13 +27,13 @@ jobs:
         token_format: access_token
         access_token_scopes: https://www.googleapis.com/auth/androidpublisher
 
-      #    - name: Download app-release.aab from artifacts
-#      uses: actions/download-artifact@v4
-#      with:
-#        name: app-release
-#        run-id: ${{ github.event.workflow_run.id }}
-#        path: ./build-artifacts
-#
+    - name: Download app-release.aab from artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: app-release
+        run-id: ${{ github.event.workflow_run.id }}
+        path: ./build-artifacts
+
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -65,11 +63,31 @@ jobs:
 
         ls -lh build-artifacts
 
+    - name: Set Track by Branch
+      id: set-track
+      run: |
+        case "${GITHUB_REF_NAME}" in
+          main)
+            echo "TRACK=production" >> $GITHUB_ENV
+            ;;
+          hotfix)
+            echo "TRACK=internal" >> $GITHUB_ENV
+            ;;
+          dev)
+            echo "TRACK=internal" >> $GITHUB_ENV
+            ;;
+          release)
+            echo "TRACK=rc" >> $GITHUB_ENV
+            ;;
+          *)
+            echo "TRACK=internal" >> $GITHUB_ENV
+            ;;
+        esac
+
     - name: Deploy to Play Store
       env:
         ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         PACKAGE_NAME: com.barlow.front
-        TRACK: internal
       run: |
         set -e
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,12 +81,12 @@ jobs:
         set -e
         
         echo "📌 1. Create Edit"
-        EDIT_ID=$(curl -s -X POST \
+        EDIT_RESPONSE=$(curl -s -X POST \
           -H "Authorization: Bearer $ACCESS_TOKEN" \
           -H "Content-Type: application/json" \
-          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits" \
-          | jq -r '.id')
-        echo "Got editId: $EDIT_ID"
+          "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PACKAGE_NAME/edits")
+        echo "Got editId: $EDIT_RESPONSE"
+        echo << (echo "$EDIT_RESPONSE" | jq -r '.id')
         
         echo "📌 2. Upload AAB"
         UPLOAD_URL="https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/$PACKAGE_NAME/edits/$EDIT_ID/bundles?uploadType=resumable"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,9 @@ jobs:
 #        run-id: ${{ github.event.workflow_run.id }}
 #        path: ./build-artifacts
 #
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Download latest CI artifact (app-release)
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,9 @@ jobs:
 
       - name: Upload .aab artifact
         uses: actions/upload-artifact@v4
-        working-directory: app
         with:
           name: app-release
-          path: ./build/app/outputs/bundle/release/app-release.aab
+          path: app/build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: error
 
       - name: Commit & push bumped pubspec.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,11 @@ jobs:
 
       - name: Build Android AppBundle(.aab)
         working-directory: app
-        run: flutter build appbundle --release \
-              --build-name ${{ steps.bump.outputs.version_name }} \
-              --build-number ${{ steps.bump.outputs.version_code }} \
-              --dart-define=FLAVOR=prod
+        run: |
+          flutter build appbundle --release \
+          --build-name ${{ steps.bump.outputs.version_name }} \
+          --build-number ${{ steps.bump.outputs.version_code }} \
+          --dart-define=FLAVOR=prod
 
       - name: Upload .aab artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,27 @@ jobs:
           channel: stable
           version: 3.29.2
 
+      - name: Generate Android Keystore File
+        shell: bash
+        working-directory: app
+        run: |
+          set -e
+          mkdir -p $HOME/.android
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/.android/release-key.jks
+          chmod 600 $HOME/.android/release-key.jks
+          
+          echo "Verifying keystore..."
+          keytool -list -keystore $HOME/.android/release-key.jks -storepass "${{ secrets.ANDROID_STORE_PASSWORD }}"
+          echo "✅ Keystore verification successful"
+          
+          cat > ./android/key.properties <<'EOF'
+          storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=upload
+          storeFile=/home/runner/.android/release-key.jks
+          storeType=pkcs12
+          EOF
+
       - name: Bump build number (+1) in app/pubspec.yaml
         id: bump
         working-directory: app
@@ -71,21 +92,6 @@ jobs:
         shell: bash
         working-directory: app
         run: dart run flutter_native_splash:create
-
-      - name: Generate Android Keystore File
-        shell: bash
-        working-directory: app
-        run: |
-          mkdir -p $HOME/.android
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/.android/release-key.jks
-          cat > ./android/key.properties <<'EOF'
-          storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
-          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
-          keyAlias=upload
-          storeFile=/home/runner/.android/release-key.jks
-          storeType=pkcs12
-          EOF
-
       - name: Build Android AppBundle(.aab)
         working-directory: app
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
         run: |
           set -e
           (cd core && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
-          (cd design_system && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
-          (cd common && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
           (cd features && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs) 
           (cd app && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,10 @@ jobs:
 
       - name: Upload .aab artifact
         uses: actions/upload-artifact@v4
+        working-directory: app
         with:
           name: app-release
-          path: app/build/outputs/bundle/release/*.aab
+          path: ./build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: error
 
       - name: Commit & push bumped pubspec.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           set -e
           mkdir -p $HOME/.android
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/.android/release-key.jks
+          echo "${{ secrets.ANDROID_RELEASE_KEY_JKS_BASE64 }}" | base64 -d > $HOME/.android/release-key.jks
           chmod 600 $HOME/.android/release-key.jks
           
           echo "Verifying keystore..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: 어플리케이션 빌드
 
 on:
   push:
-    branches: [deploy, hotfix, issue/51]
+    branches: [main, release, hotfix, dev, issue/51]
   workflow_dispatch:
 
 permissions:
@@ -60,11 +60,26 @@ jobs:
           CODE=$(echo "$LINE" | awk -F'+' '{print $2}')             # 45
           NEW_CODE=$((CODE+1))
           
+          # 브랜치별 접미사 결정
+          if [[ "$BRANCH" == dev* ]]; then
+            SUFFIX="-alpha"
+          elif [[ "$BRANCH" == release* ]]; then
+            SUFFIX="-rc"
+          elif [[ "$BRANCH" == hotfix* ]]; then
+            SUFFIX=""   # prefix 없음
+          elif [[ "$BRANCH" == main ]]; then
+            SUFFIX=""   # prefix 없음
+          else
+            SUFFIX=""   # 기본값
+          fi
+          
+          NEW_NAME="${NAME}${SUFFIX}"
+          
           echo "current: $NAME+$CODE"
-          echo "new:     $NAME+$NEW_CODE"
+          echo "new:     $NEW_NAME+$NEW_CODE"
           
           # pubspec.yaml 덮어쓰기
-          sed -i "s/^version: .*/version: ${NAME}+${NEW_CODE}/" pubspec.yaml
+          sed -i "s/^version: .*/version: ${NEW_NAME}+${NEW_CODE}/" pubspec.yaml
           
           # 빌드 인자로 넘길 값 export
           echo "version_name=$NAME" >> $GITHUB_OUTPUT
@@ -92,6 +107,7 @@ jobs:
         shell: bash
         working-directory: app
         run: dart run flutter_native_splash:create
+
       - name: Build Android AppBundle(.aab)
         working-directory: app
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           keyAlias=upload
           storeFile=/home/runner/.android/release-key.jks
+          storeType=pkcs12
           EOF
 
       - name: Build Android AppBundle(.aab)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,12 @@ jobs:
         run: |
           mkdir -p $HOME/.android
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/.android/release-key.jks
-          cat > android/key.properties <<EOF
-          storePassword="${{ secrets.ANDROID_STORE_PASSWORD }}"
-          keyPassword="${{ secrets.ANDROID_KEY_PASSWORD }}"
-          keyAlias=upload
-          storeFile=/home/runner/.android/release-key.jks
+          cat > android/key.properties <<'EOF'
+storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
+keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+keyAlias=upload
+storeFile=/home/runner/.android/release-key.jks
+EOF
 
       - name: Build Android AppBundle(.aab)
         working-directory: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,117 @@
+name: 어플리케이션 빌드
+
+on:
+  push:
+    branches: [deploy, hotfix, issue/51]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JAVA 18 SDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '18'
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          channel: stable
+          version: 3.29.2
+
+      - name: Bump build number (+1) in app/pubspec.yaml
+        id: bump
+        working-directory: app
+        shell: bash
+        run: |
+          set -e
+          # version 라인 추출 (예: "version: 1.2.3+45")
+          LINE=$(grep -E '^version:' pubspec.yaml)
+          NAME=$(echo "$LINE" | awk '{print $2}' | cut -d'+' -f1)   # 1.2.3
+          CODE=$(echo "$LINE" | awk -F'+' '{print $2}')             # 45
+          NEW_CODE=$((CODE+1))
+          
+          echo "current: $NAME+$CODE"
+          echo "new:     $NAME+$NEW_CODE"
+          
+          # pubspec.yaml 덮어쓰기
+          sed -i "s/^version: .*/version: ${NAME}+${NEW_CODE}/" pubspec.yaml
+          
+          # 빌드 인자로 넘길 값 export
+          echo "version_name=$NAME" >> $GITHUB_OUTPUT
+          echo "version_code=$NEW_CODE" >> $GITHUB_OUTPUT
+
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -e
+          for dir in app common core design_system features; do
+            echo ">>> flutter pub get in $dir"
+            (cd "$dir" && flutter pub get)
+          done
+
+      - name: Generating Injectable
+        shell: bash
+        run: |
+          set -e
+          for dir in app common core design_system features; do
+            echo ">>> dart run build_runner build in $dir"
+            (cd "$dir" && dart run build_runner build)
+          done
+
+      - name: Generate Native Splash
+        shell: bash
+        working-directory: app
+        run: dart run flutter_native_splash:create
+
+      - name: Generate Android Keystore File
+        shell: bash
+        working-directory: app
+        run: |
+          mkdir -p $HOME/.android
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/.android/release-key.jks
+          cat > android/key.properties <<EOF
+          storePassword="${{ secrets.ANDROID_STORE_PASSWORD }}"
+          keyPassword="${{ secrets.ANDROID_KEY_PASSWORD }}"
+          keyAlias=upload
+          storeFile=/home/runner/.android/release-key.jks
+
+      - name: Build Android AppBundle(.aab)
+        working-directory: app
+        run: flutter build appbundle --dart-define=FLAVOR=prod \
+              --build-name ${{ steps.bump.outputs.version_name }} \
+              --build-number ${{ steps.bump.outputs.version_code }} \
+              --dart-define=FLAVOR=prod
+
+      - name: Upload .aab artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/bundle/release/*.aab
+          if-no-files-found: error
+
+      - name: Commit & push bumped pubspec.yaml
+        if: ${{ success() }}
+        shell: bash
+        working-directory: app
+        run: |
+          set -e
+          git config user.name  "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          
+          if ! git diff --quiet -- pubspec.yaml; then
+            git add pubspec.yaml
+            git commit -m "ci: bump build number to ${{ steps.bump.outputs.version_code }}"
+            git push
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Build Android AppBundle(.aab)
         working-directory: app
-        run: flutter build appbundle -- release\
+        run: flutter build appbundle --release \
               --build-name ${{ steps.bump.outputs.version_name }} \
               --build-number ${{ steps.bump.outputs.version_code }} \
               --dart-define=FLAVOR=prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,12 @@ jobs:
         run: |
           mkdir -p $HOME/.android
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/.android/release-key.jks
-          cat > android/key.properties <<'EOF'
-storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
-keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
-keyAlias=upload
-storeFile=/home/runner/.android/release-key.jks
-EOF
+          cat > ./android/key.properties <<'EOF'
+          storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=upload
+          storeFile=/home/runner/.android/release-key.jks
+          EOF
 
       - name: Build Android AppBundle(.aab)
         working-directory: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,11 @@ jobs:
         shell: bash
         run: |
           set -e
-          for dir in app common core design_system features; do
-            echo ">>> dart run build_runner build in $dir"
-            (cd "$dir" && dart run build_runner build)
-          done
+          (cd core && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
+          (cd design_system && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
+          (cd common && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
+          (cd features && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs) 
+          (cd app && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs)
 
       - name: Generate Native Splash
         shell: bash

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -60,76 +60,8 @@ android {
             ]
         }
     }
-
-//    flavorDimensions "default"
-//    productFlavors {
-//        dev {
-//            dimension "default"
-////            applicationIdSuffix ".dev"
-//            versionNameSuffix "-dev"
-//        }
-//        prod {
-//            dimension "default"
-//        }
-//
-//    }
 }
 
 flutter {
     source = "../.."
 }
-//
-//android.applicationVariants.all { variant ->
-//    def flavor = variant.flavorName
-//    def buildType = variant.buildType.name
-//
-//    variant.outputs.all { output ->
-//        def extension = output.outputFileName?.split("\\.")?.last() ?: "aab"
-//        def versionName = variant.versionName
-//        def newName = "barlow-${flavor}-${versionName}-${buildType}.${extension}"
-//
-//        output.outputFileName = newName
-//    }
-//}
-//
-//gradle.taskGraph.whenReady { taskGraph ->
-//    if (taskGraph.hasTask(":app:bundleProdRelease")) {
-//        def versionName = android.defaultConfig.versionName
-//        def flavor = "prod"
-//        def srcFile = file("$buildDir/outputs/bundle/${flavor}Release/app-${flavor}-release.aab")
-//        def destFile = file("$buildDir/outputs/bundle/${flavor}Release/barlow-${flavor}-v${versionName}-release.aab")
-//
-//        tasks.named("bundleProdRelease").configure {
-//            doLast {
-//                println "✅ [Gradle Hook] bundleProdRelease 실행됨"
-//                if (srcFile.exists()) {
-//                    FileUtils.copyFile(srcFile, destFile)
-//                    println "✅ Copied AAB to: ${destFile.name}"
-//                } else {
-//                    println "⚠️ AAB file not found: ${srcFile}"
-//                }
-//            }
-//        }
-//    }
-////}
-//gradle.taskGraph.whenReady { taskGraph ->
-//    // 오직 AAB 빌드일 때만 Hook 실행
-//    if (taskGraph.hasTask(":app:bundleProdRelease")) {
-//        def flavor = "prod"
-//        def versionName = android.defaultConfig.versionName
-//        def srcFile = file("$buildDir/outputs/bundle/${flavor}Release/app-${flavor}-release.aab")
-//        def destFile = file("$buildDir/outputs/bundle/${flavor}Release/barlow-${flavor}-v${versionName}-release.aab")
-//
-//        tasks.named("bundleProdRelease").configure {
-//            doLast {
-//                println "✅ [Gradle Hook] bundleProdRelease 실행됨"
-//                if (srcFile.exists()) {
-//                    FileUtils.copyFile(srcFile, destFile)
-//                    println "✅ Copied AAB to: ${destFile.name}"
-//                } else {
-//                    println "⚠️ AAB file not found: ${srcFile}"
-//                }
-//            }
-//        }
-//    }
-//}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:core/utils/device_info_manager.dart';
 import 'package:core/notification/fcm_config.dart';
 import 'package:features/barlow_app.dart';
 import 'package:core/storage/hive/hive_configs.dart';
+import 'package:core/notification/firebase_remote_config_initializer.dart';
 
 import 'di.dart';
 
@@ -24,12 +25,13 @@ void main() async {
     configureDependencies(_flavor);
   }
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
-  FcmInitializer(
+  await FcmInitializer(
     plugin: FlutterLocalNotificationsPlugin(),
     onMessageForegroundHandler: (RemoteMessage message) {},
     onMessageBackgroundHandler: (RemoteMessage message) {},
     onMessageTerminatedHandler: (RemoteMessage message) {},
   ).initialize();
+  await FirebaseRemoteConfigInitializer().initialize();
   await DeviceInfoManager().init();
   FlutterNativeSplash.remove();
   runApp(barlowMobileApp);

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: front
 description: "국회의원 정보 및 발의 법안 정보 제공 프로젝트"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.1-alpha+9
+version: 1.0.1-alpha+10
 
 environment:
   sdk: ^3.5.4

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: front
 description: "국회의원 정보 및 발의 법안 정보 제공 프로젝트"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.1-alpha+10
+version: 1.0.1+10
 
 environment:
   sdk: ^3.5.4

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,29 +2,11 @@ name: front
 description: "국회의원 정보 및 발의 법안 정보 제공 프로젝트"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0-alpha+8
+version: 1.0.0+9
 
 environment:
   sdk: ^3.5.4
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
@@ -33,8 +15,6 @@ dependencies:
   core:
     path: ../core
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.g
   firebase_core: ^3.13.0
   firebase_messaging: ^15.2.5
   flutter_local_notifications: ^19.0.0
@@ -50,33 +30,16 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^4.0.0
   test: ^1.25.8
   build_runner: ^2.4.15
   injectable_generator: ^2.6.2
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
   assets:
     - assets/icons/app/
     - assets/pictures/
-    
   fonts:
     - family: GmarketSans
       fonts:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: front
 description: "국회의원 정보 및 발의 법안 정보 제공 프로젝트"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.1+10
+version: 1.0.1+11
 
 environment:
   sdk: ^3.5.4

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: front
 description: "국회의원 정보 및 발의 법안 정보 제공 프로젝트"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+9
+version: 1.0.1-alpha+9
 
 environment:
   sdk: ^3.5.4

--- a/core/lib/notification/firebase_manager.dart
+++ b/core/lib/notification/firebase_manager.dart
@@ -35,4 +35,5 @@ class RemoteConfigManager{
 
   String readPlayStoreUrl() => _firebaseRemoteConfig.getString("androidStoreUrl");
 
+  bool isServerUnderMaintenance() => _firebaseRemoteConfig.getBool("isServerUnderMaintenance");
 }

--- a/core/lib/notification/firebase_remote_config_initializer.dart
+++ b/core/lib/notification/firebase_remote_config_initializer.dart
@@ -1,0 +1,19 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+
+class FirebaseRemoteConfigInitializer {
+
+  final FirebaseRemoteConfig _remoteConfig = FirebaseRemoteConfig.instance;
+
+  Future<void> initialize() async {
+    await _remoteConfig.setConfigSettings(RemoteConfigSettings(
+      fetchTimeout: const Duration(seconds: 10),
+      minimumFetchInterval: Duration.zero,
+    ));
+
+    await _remoteConfig.setDefaults(const {
+      'isServerUnderMaintenance': false, // 기본값
+    });
+
+    await _remoteConfig.fetchAndActivate();
+  }
+}

--- a/core/lib/notification/firebase_remote_config_initializer.dart
+++ b/core/lib/notification/firebase_remote_config_initializer.dart
@@ -11,7 +11,7 @@ class FirebaseRemoteConfigInitializer {
     ));
 
     await _remoteConfig.setDefaults(const {
-      'isServerUnderMaintenance': false, // 기본값
+      'isServerUnderMaintenance': false,
     });
 
     await _remoteConfig.fetchAndActivate();

--- a/features/lib/splash/domain/repositories/app_version_status_repository.dart
+++ b/features/lib/splash/domain/repositories/app_version_status_repository.dart
@@ -3,4 +3,6 @@ import 'package:features/splash/domain/entities/app_version_status.dart';
 abstract interface class AppVersionStatusRepository {
 
   Future<AppVersionStatus> fetchVersionInfo();
+
+  Future<bool> fetchServerUnderMaintenanceInfo();
 }

--- a/features/lib/splash/domain/serivce/app_version_status_remote_config_repository_adapter.dart
+++ b/features/lib/splash/domain/serivce/app_version_status_remote_config_repository_adapter.dart
@@ -42,4 +42,9 @@ class AppVersionStatusRemoteConfigRepositoryAdapter implements AppVersionStatusR
   Future<AppVersionStatus> fetchVersionInfo() async {
     return _service.checkAppVersion();
   }
+
+  @override
+  Future<bool> fetchServerUnderMaintenanceInfo() async {
+    return _service._remoteConfigManager.isServerUnderMaintenance();
+  }
 }

--- a/features/lib/splash/domain/usecases/retrieve_app_initialize_info_usecase.dart
+++ b/features/lib/splash/domain/usecases/retrieve_app_initialize_info_usecase.dart
@@ -14,6 +14,7 @@ class AppInitializeStatus {
   final bool isLoggedIn;
   final bool hasCheckNotificationPermission;
   final bool hasRejectUpdateDialog;
+  final bool isSeverUnderMaintenance;
 
   AppInitializeStatus({
       required this.isFirstLaunch,
@@ -21,7 +22,8 @@ class AppInitializeStatus {
       required this.needForceUpdate,
       required this.isLoggedIn,
       required this.hasCheckNotificationPermission,
-      required this.hasRejectUpdateDialog
+      required this.hasRejectUpdateDialog,
+      required this.isSeverUnderMaintenance
   });
 }
 
@@ -42,13 +44,15 @@ class RetrieveAppInitializeInfoUseCase {
     AppVersionStatus versionStatus = await _appVersionStatusRepository.fetchVersionInfo();
     final rejectUpdateDialog = await _userRejectRepository.findByCategory(UserRejectCategory.updateAvailableDialog);
     bool hasRejectDialog = (rejectUpdateDialog != null) && (rejectUpdateDialog.expiredAt.isAfter(DateTime.now()));
+    bool isServerUnderMaintenance = await _appVersionStatusRepository.fetchServerUnderMaintenanceInfo();
     return AppInitializeStatus(
       isFirstLaunch: info.isFirstLaunch,
       isLoggedIn: info.isLoggedIn,
       hasCheckNotificationPermission: info.hasCheckNotificationPermission,
       isUpdateAvailable: versionStatus == AppVersionStatus.updateAvailable,
       needForceUpdate: versionStatus == AppVersionStatus.needForceUpdate,
-      hasRejectUpdateDialog: hasRejectDialog
+      hasRejectUpdateDialog: hasRejectDialog,
+      isSeverUnderMaintenance: isServerUnderMaintenance
     );
   }
 }

--- a/features/lib/splash/presentation/viewmodel/splash_viewmodel.dart
+++ b/features/lib/splash/presentation/viewmodel/splash_viewmodel.dart
@@ -18,6 +18,7 @@ class AppInitializeState {
   final bool isUpdateAvailable;
   final bool hasRejectUpdateDialog;
   final bool refreshFlag;
+  final bool isServerUnderMaintenance;
 
   const AppInitializeState({
     required this.needForceUpdate,
@@ -27,6 +28,7 @@ class AppInitializeState {
     required this.isUpdateAvailable,
     required this.hasRejectUpdateDialog,
     required this.refreshFlag,
+    required this.isServerUnderMaintenance
   });
 
   AppInitializeState copyWith({
@@ -37,6 +39,7 @@ class AppInitializeState {
     bool? isUpdateAvailable,
     bool? hasRejectUpdateDialog,
     bool? refreshFlag,
+    bool? isServerUnderMaintenance
   }) {
     return AppInitializeState(
       needForceUpdate: needForceUpdate ?? this.needForceUpdate,
@@ -46,6 +49,7 @@ class AppInitializeState {
       isUpdateAvailable: isUpdateAvailable ?? this.isUpdateAvailable,
       hasRejectUpdateDialog: hasRejectUpdateDialog ?? this.hasRejectUpdateDialog,
       refreshFlag: refreshFlag ?? this.refreshFlag,
+      isServerUnderMaintenance: isServerUnderMaintenance ?? this.isServerUnderMaintenance
     );
   }
 }
@@ -75,6 +79,7 @@ class AppInitializeInfoNotifier extends StateNotifier<AsyncValue<AppInitializeSt
         isFirstLaunch: appInitializeInfo.isFirstLaunch,
         isLoggedIn: appInitializeInfo.isLoggedIn,
         refreshFlag: false,
+        isServerUnderMaintenance: appInitializeInfo.isSeverUnderMaintenance
       ));
     } catch (e, st) {
       state = AsyncValue.error(e, st);


### PR DESCRIPTION
## CI/CD 파이프 라인 구축

### CI.yml
ci.yml은 특정 브랜치 푸쉬 이후 자동 빌드
브랜치 명에 따라 versionname의 suffix 분기
- main -> "" 정식 릴리즈
- hotfix/ -> "" 정식 릴리즈
- release/ -> "-rc" release candidate
- dev/ -> "-alpha"

이후 .aab를 artifcat로 생성합니다.

지속적 통합은 dev브랜치를 통해 -alpha버전으로 병합됨

### cd.yml
cd.yml은 특정 브랜치에 따라 playconsole의 특정 트랙에 배포됨
ci.yml에서 생성된 artifact를 통해 다음의 트랙으로 배포함
- main -> procuction 트랙
- hotfix -> 내부 테스트 트랙
- release/ -> 비공개 테스트 트랙(트랙명 rc)
- dev/ -> 내부 테스트 트랙

## 서버 점검 화면 추가
서버 점검 flag를 remote config에서 가져와 앱 실행 여부를 결정합니다.

